### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -16,7 +16,7 @@
   "depends": [
   ],
   "tags": [ "download", "utility", "http" ],
-  "license": "perl",
+  "license": "Artistic-2.0",
   "test-depends": [
      "Test"
   ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license